### PR TITLE
highlight modules

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -7,6 +7,14 @@
 (constant
   name: (identifier) @constant)
 
+; Modules
+(module) @module
+(import alias: (identifier) @module)
+((function_call function: (field_access record: (identifier) @module))
+ (#is-not? local))
+((binary_expression "|>" (field_access record: (identifier) @module))
+ (#is-not? local))
+
 ; Functions
 (function
   name: (identifier) @function)

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -10,6 +10,7 @@
 ; Modules
 (module) @module
 (import alias: (identifier) @module)
+(remote_type_identifier module: (identifier) @module)
 ((function_call function: (field_access record: (identifier) @module))
  (#is-not? local))
 ((binary_expression "|>" (field_access record: (identifier) @module))

--- a/queries/locals.scm
+++ b/queries/locals.scm
@@ -1,0 +1,13 @@
+; Scopes
+(function_body) @local.scope
+
+; Definitions
+(let pattern: (identifier) @local.definition)
+(function_parameter name: (identifier) @local.definition)
+(list_pattern (identifier) @local.definition)
+(list_pattern assign: (identifier) @local.definition)
+(tuple_pattern (identifier) @local.definition)
+(record_pattern_argument pattern: (identifier) @local.definition)
+
+; References
+(identifier) @local.reference

--- a/test/highlight/functions.gleam
+++ b/test/highlight/functions.gleam
@@ -23,14 +23,14 @@ pub fn replace(
   // ^ type
   //        ^ punctuation.bracket
   string.replace(in: string, each: pattern, with: replacement)
-  // <- variable
+  // <- variable.parameter
   //     ^ property
   //             ^ property
-  //                 ^ variable
+  //                 ^ variable.parameter
   //                         ^ property
-  //                               ^ variable
+  //                               ^ variable.parameter
   //                                        ^ property
-  //                                              ^ variable
+  //                                              ^ variable.parameter
 }
 
 fn trial(uri) {

--- a/test/highlight/functions.gleam
+++ b/test/highlight/functions.gleam
@@ -3,11 +3,11 @@ pub fn replace(
   // <- keyword
   //   ^ function
   //          ^ punctuation.bracket
-  in string: String,
+  in original: String,
   // <- property
   // ^ variable.parameter
-  //         ^ type
-  //               ^ punctuation.delimeter
+  //            ^ type
+  //                 ^ punctuation.delimeter
   each pattern: String,
   // <- property
   //   ^ variable.parameter
@@ -22,15 +22,15 @@ pub fn replace(
   // <- punctuation.delimeter
   // ^ type
   //        ^ punctuation.bracket
-  string.replace(in: string, each: pattern, with: replacement)
-  // <- variable.parameter
-  //     ^ property
-  //             ^ property
-  //                 ^ variable.parameter
-  //                         ^ property
-  //                               ^ variable.parameter
-  //                                        ^ property
-  //                                              ^ variable.parameter
+  string.replace(in: original, each: pattern, with: replacement)
+  // <- module
+  //        ^ property
+  //              ^ property
+  //                  ^ variable.parameter
+  //                            ^ property
+  //                                  ^ variable.parameter
+  //                                           ^ property
+  //                                                 ^ variable.parameter
 }
 
 fn trial(uri) {

--- a/test/highlight/modules.gleam
+++ b/test/highlight/modules.gleam
@@ -31,3 +31,10 @@ fn pipe_operator_case(string: String) {
   |> iodata.reverse
   // ^ module
 }
+
+fn remote_type_case() {
+  gleam.Ok(1)
+  // <- module
+  //   ^ punctuation.delimeter
+  //     ^ type
+}

--- a/test/highlight/modules.gleam
+++ b/test/highlight/modules.gleam
@@ -1,0 +1,33 @@
+import gleam/io
+//     ^ module
+//          ^ module
+//           ^ module
+import animal/cat as kitty
+//      ^ module
+//                    ^ module
+
+pub fn main() {
+  io.println("hello world")
+  // <- module
+}
+
+type MyType {
+  MyType(func: fn() -> Int)
+}
+
+fn record_access_case(param: MyType) {
+  let binding = MyType(func: fn() { 42 })
+  let _ = binding.func()
+  //       ^ variable
+  let _ = param.func()
+  //       ^ variable.parameter
+}
+
+fn pipe_operator_case(string: String) {
+  string
+  // <- variable.parameter
+  |> iodata.new
+  // ^ module
+  |> iodata.reverse
+  // ^ module
+}


### PR DESCRIPTION
:wave: hello!

This grammar is awesome, great work! :heart_eyes: 

I think it's possible to highlight modules. There's this query which is pretty straight-forward:

```tsq
(module) @module
```

which captures things like

```gleam
import gleam/io
```

But as you mention in the readme, it's a bit ambiguous what to do in this case:

```gleam
fn pipe_case() {
  string
  |> iodata.new
  |> iodata.reverse
}
```

Because you might have a record with function that looks syntactically the same.

```gleam
type Foo {
  Foo(bar: fn() -> Int)
}

pub fn main() {
  let f = Foo(bar: fn() { 5 })
  let _ = f.bar() // 'f' is a module? or a variable?
}
```

So to get around that, I believe we can use `local.scm` queries, which define scopes and capture variable definitions and usages ("references"). We can be pretty confident that if we have a function call or pipe and a record access, it's variable if that variable has been defined in the current scope, and otherwise we can say that it's a module. I think I have all the cases of variable definitions correct here, but it's always complicated in languages that have destructuring :sweat_smile:, let me know if I missed some!

What do you think?
