### PR TITLE
fix typo in punctuation.delimiter highlight capture

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -129,4 +129,4 @@
   "="
   "->"
   ".."
-] @punctuation.delimeter
+] @punctuation.delimiter

--- a/test/highlight/functions.gleam
+++ b/test/highlight/functions.gleam
@@ -7,19 +7,19 @@ pub fn replace(
   // <- property
   // ^ variable.parameter
   //            ^ type
-  //                 ^ punctuation.delimeter
+  //                 ^ punctuation.delimiter
   each pattern: String,
   // <- property
   //   ^ variable.parameter
   //             ^ type
-  //                  ^ punctuation.delimeter
+  //                  ^ punctuation.delimiter
   with replacement: String,
   // <- property
   //   ^ variable.parameter
   //                ^ type
-  //                      ^ punctuation.delimeter
+  //                      ^ punctuation.delimiter
 ) -> String {
-  // <- punctuation.delimeter
+  // <- punctuation.delimiter
   // ^ type
   //        ^ punctuation.bracket
   string.replace(in: original, each: pattern, with: replacement)

--- a/test/highlight/modules.gleam
+++ b/test/highlight/modules.gleam
@@ -35,6 +35,6 @@ fn pipe_operator_case(string: String) {
 fn remote_type_case() {
   gleam.Ok(1)
   // <- module
-  //   ^ punctuation.delimeter
+  //   ^ punctuation.delimiter
   //     ^ type
 }


### PR DESCRIPTION
I make this same typo all the time :smile: 

It's not very noticeable because highlighters fall back to `punctuation` when `punctuation.delimeter` isn't defined, so you still get punctuation highlights, it just looks different than if you theme `punctuation.delimiter` to some other color