### PR TITLE
add CI and tune up git config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/src/**/* linguist-generated=true
+/bindings/**/* linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-/src/**/* linguist-generated=true
-/bindings/**/* linguist-generated=true
+/src/**/* linguist-vendored=true
+/bindings/**/* linguist-vendored=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  bless:
+    name: Bless
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Ensure generated parser files are up to date
+        run: npx tree-sitter generate
+
+      - name: Run tree-sitter tests
+        run: npx tree-sitter test
+
+      - name: Check formatting
+        run: npm run check-formatted

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   bless:
-    name: Bless
+    name: Test
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/generate-parser.yml
+++ b/.github/workflows/generate-parser.yml
@@ -1,0 +1,41 @@
+# generates the parser with 'tree-sitter generate' if the parser is out of date
+name: Generate Parser
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  generate:
+    name: Generate Parser
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Generate parser files
+        run: npx tree-sitter generate
+
+      - name: Commit generated parser files
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Generate parser
+          file_pattern: src

--- a/.github/workflows/generate-parser.yml
+++ b/.github/workflows/generate-parser.yml
@@ -35,7 +35,9 @@ jobs:
         run: npx tree-sitter generate
 
       - name: Commit generated parser files
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Generate parser
-          file_pattern: src
+        run: |
+          git config --local user.email "$(git log --format='%ae' HEAD^!)"
+          git config --local user.name "$(git log --format='%an' HEAD^!)"
+          git add src
+          git commit -m "Generate parser" || true
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 target
 build
+*.wasm
+log.html

--- a/grammar.js
+++ b/grammar.js
@@ -631,7 +631,8 @@ module.exports = grammar({
         optional($.list_pattern_tail),
         "]"
       ),
-    list_pattern_tail: ($) => seq("..", optional(choice($.identifier, $.discard))),
+    list_pattern_tail: ($) =>
+      seq("..", optional(choice($.identifier, $.discard))),
 
     /* Public functions */
     public_function: ($) => seq("pub", $._function),


### PR DESCRIPTION
few things here:

- github actions CI that runs tests and checks formatting on PRs and pushes
- some additions to the `.gitignore` for some tree-sitter generated files that are not usually checked in
- a `.gitattributes` that marks generated files as generated
    - this makes diffs to those files auto-collapse in PR/commit diffs
    - and it excludes them from linguist's language inference for the repo, so the repo will become "a javascript repo" according to linguist, rather than a C repo
- I ran the formatter (I forgot in #3 :sweat_smile:)

what do you think?