### PR TITLE
Consider the "field" of field accesses to be a function wherever the "record" is a module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "prettier": "^2.5.1",
-        "tree-sitter-cli": "^0.20.1"
+        "tree-sitter-cli": "^0.20.4"
       }
     },
     "node_modules/nan": {
@@ -34,9 +34,9 @@
       }
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.1.tgz",
-      "integrity": "sha512-I0Gp4ThRp39TDnBAaZKiogvoE85MSeL6/ILZMXbzeEo8hUsudpVhEHRE4CU+Bk5QUaiMiDkD+ZIL3gT2zZ++wg==",
+      "version": "0.20.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.4.tgz",
+      "integrity": "sha512-G42x0Ev7mxA8WLUfZY+two5LIhPf6R/m7qDZtKxOzE77zXi6didNI/vf17kHaKaRXJrWnyCxHFaVQFO2LL81yg==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -57,9 +57,9 @@
       "dev": true
     },
     "tree-sitter-cli": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.1.tgz",
-      "integrity": "sha512-I0Gp4ThRp39TDnBAaZKiogvoE85MSeL6/ILZMXbzeEo8hUsudpVhEHRE4CU+Bk5QUaiMiDkD+ZIL3gT2zZ++wg==",
+      "version": "0.20.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.4.tgz",
+      "integrity": "sha512-G42x0Ev7mxA8WLUfZY+two5LIhPf6R/m7qDZtKxOzE77zXi6didNI/vf17kHaKaRXJrWnyCxHFaVQFO2LL81yg==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -31,12 +31,14 @@
   },
   "devDependencies": {
     "prettier": "^2.5.1",
-    "tree-sitter-cli": "^0.20.1"
+    "tree-sitter-cli": "^0.20.4"
   },
   "tree-sitter": [
     {
       "scope": "source.gleam",
-      "file-types": ["gleam"],
+      "file-types": [
+        "gleam"
+      ],
       "injection-regex": "^gleam$"
     }
   ]

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -12,18 +12,9 @@
 (import alias: (identifier) @module)
 (remote_type_identifier
   module: (identifier) @module)
-
-((function_call
-   function: (field_access
-     record: (identifier) @module
-     field: (label) @function))
- (#is-not? local))
-
-((binary_expression
-   operator: "|>"
-   right: (field_access
-     record: (identifier) @module
-     field: (label) @function))
+((field_access
+  record: (identifier) @module
+  field: (label) @function)
  (#is-not? local))
 
 ; Functions

--- a/test/highlight/functions.gleam
+++ b/test/highlight/functions.gleam
@@ -41,6 +41,19 @@ pub fn replace(
   //                         ^ variable.parameter
 }
 
+fn record_with_fun_field(record) {
+  let foo = Bar(baz: fn(x) { x + 1 })
+  foo.baz(41)
+  // <- variable
+  //  ^ property
+  record.foobar("hello")
+  // ^ variable.parameter
+  //     ^ property
+  string.replace("hello", "l", "o")
+  // ^ module
+  //     ^ function
+}
+
 fn trial(uri) {
   //      ^ variable.parameter
   case uri {


### PR DESCRIPTION
Currently we only consider the possibility for a `field_access` to actually be a remote function when it is being used in a function call expression or on the right side of a pipe. However, there is at least one other case where this could be true:

```rust
let foo = io.println
foo("Hello, World!")
```

Here, `io.println` is a remote function which is being bound to the local variable `foo`.

In order to catch this and other circumstances where a `field_access` may actually be a remote function reference, I generalized the highlight matcher.

I also added a test to ensure that highlighting of remote function invocations behaves as we expect.