### PR TITLE
add tags.scm queries

### DIFF
--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -1,0 +1,54 @@
+; Modules
+(module) @name @reference.module
+(import alias: (identifier) @name) @reference.module
+(remote_type_identifier
+  module: (identifier) @name) @reference.module
+((field_access
+  record: (identifier) @name)
+ (#is-not? local)) @reference.module
+
+; Functions
+(function
+  name: (identifier) @name) @definition.function
+(public_function
+  name: (identifier) @name) @definition.function
+(external_function
+  name: (identifier) @name) @definition.function
+(public_external_function
+  name: (identifier) @name) @definition.function
+(unqualified_import (identifier) @name) @reference.function
+((function_call
+   function: (identifier) @name) @reference.function
+ (#is-not? local))
+((field_access
+  record: (identifier) @ignore
+  field: (label) @name)
+ (#is-not? local)) @reference.function
+((binary_expression
+   operator: "|>"
+   right: (identifier) @name)
+ (#is-not? local)) @reference.function
+
+; Types
+(public_type_definition
+  (type_name
+    name: (type_identifier) @name)) @definition.type
+(type_definition
+  (type_name
+    name: (type_identifier) @name)) @definition.type
+(public_type_definition
+  (type_constructors
+    (type_constructor
+      name: (type_identifier) @name))) @definition.type
+(type_definition
+  (type_constructors
+    (type_constructor
+      name: (type_identifier) @name))) @definition.type
+(external_type
+  (type_name
+    name: (type_identifier) @name)) @definition.type
+(public_external_type
+  (type_name
+    name: (type_identifier) @name)) @definition.type
+
+(type_identifier) @name @reference.type


### PR DESCRIPTION
connects #14

I'm not sure I got them all, plus I'd like to add some tests (see https://github.com/tree-sitter/tree-sitter/pull/1547). This PR makes me think that maybe the `pub` visibility qualifier might want to be its own node under `type_definition` or function definitions? I think that might simplify the queries but I don't know if that's a good enough reason to refactor nodes. (Also, I use tree-sitter nodes for motion in my editor (see https://github.com/helix-editor/helix/pull/1495) and I think jumping to the `pub` token could occassionally be valuable, wydt?)