### PR TITLE
add visibility_modifier and opacity_modifier rules for "pub" and "opaque"

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -27,19 +27,11 @@ module.exports = grammar({
       choice(
         $.import,
         $.constant,
-        $.public_constant,
         $.external_type,
-        $.public_external_type,
         $.external_function,
-        $.public_external_function,
         $.function,
-        $.public_function,
         $.type_definition,
-        $.public_type_definition,
-        $.public_opaque_type_definition,
-        $.type_alias,
-        $.public_type_alias,
-        $.public_opaque_type_alias
+        $.type_alias
       ),
 
     /* Comments */
@@ -76,10 +68,9 @@ module.exports = grammar({
       ),
 
     /* Constant statements */
-    public_constant: ($) => seq("pub", $._constant),
-    constant: ($) => $._constant,
-    _constant: ($) =>
+    constant: ($) =>
       seq(
+        optional($.visibility_modifier),
         "const",
         field("name", $.identifier),
         optional($._constant_type_annotation),
@@ -149,16 +140,13 @@ module.exports = grammar({
       ),
     constant_type_argument: ($) => $._constant_type,
 
-    /* External types */
-    public_external_type: ($) => seq("pub", $._external_type),
-    external_type: ($) => $._external_type,
-    _external_type: ($) => seq("external", "type", $.type_name),
+    external_type: ($) =>
+      seq(optional($.visibility_modifier), "external", "type", $.type_name),
 
-    /* External functions */
-    public_external_function: ($) => seq("pub", $._external_function),
-    external_function: ($) => $._external_function,
-    _external_function: ($) =>
+    /* External function */
+    external_function: ($) =>
       seq(
+        optional($.visibility_modifier),
         "external",
         "fn",
         field("name", $.identifier),
@@ -192,9 +180,9 @@ module.exports = grammar({
     external_function_body: ($) => seq($.string, $.string),
 
     /* Functions */
-    function: ($) => $._function,
-    _function: ($) =>
+    function: ($) =>
       seq(
+        optional($.visibility_modifier),
         "fn",
         field("name", $.identifier),
         field("parameters", $.function_parameters),
@@ -552,17 +540,20 @@ module.exports = grammar({
     list_pattern_tail: ($) =>
       seq("..", optional(choice($.identifier, $.discard))),
 
-    /* Public functions */
-    public_function: ($) => seq("pub", $._function),
+    visibility_modifier: ($) => "pub",
+    opacity_modifier: ($) => "opaque",
 
     /* Custom type definitions */
-    type_definition: ($) => seq("type", $._custom_type_definition),
-    public_type_definition: ($) =>
-      seq("pub", "type", $._custom_type_definition),
-    public_opaque_type_definition: ($) =>
-      seq("pub", "opaque", "type", $._custom_type_definition),
-    _custom_type_definition: ($) =>
-      seq($.type_name, "{", $.data_constructors, "}"),
+    type_definition: ($) =>
+      seq(
+        optional($.visibility_modifier),
+        optional($.opacity_modifier),
+        "type",
+        $.type_name,
+        "{",
+        $.data_constructors,
+        "}"
+      ),
     data_constructors: ($) => repeat1($.data_constructor),
     data_constructor: ($) =>
       seq(
@@ -575,11 +566,15 @@ module.exports = grammar({
       seq(optional(seq(field("label", $.label), ":")), field("value", $._type)),
 
     /* Type aliases */
-    type_alias: ($) => seq("type", $._type_alias),
-    public_type_alias: ($) => seq("pub", "type", $._type_alias),
-    public_opaque_type_alias: ($) =>
-      seq("pub", "opaque", "type", $._type_alias),
-    _type_alias: ($) => seq($.type_name, "=", $._type),
+    type_alias: ($) =>
+      seq(
+        optional($.visibility_modifier),
+        optional($.opacity_modifier),
+        "type",
+        $.type_name,
+        "=",
+        $._type
+      ),
 
     /* Literals */
     string: ($) => seq('"', repeat($._string_part), '"'),

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -21,11 +21,7 @@
 (unqualified_import (identifier) @function)
 (function
   name: (identifier) @function)
-(public_function
-  name: (identifier) @function)
 (external_function
-  name: (identifier) @function)
-(public_external_function
   name: (identifier) @function)
 (function_parameter
   name: (identifier) @variable.parameter)
@@ -64,18 +60,17 @@
 
 ; Keywords
 [
+  (visibility_modifier) ; "pub"
+  (opacity_modifier) ; "opaque"
   "as"
   "assert"
   "case"
   "const"
   "external"
-  "pub"
   "fn"
   "if"
   "import"
   "let"
-  "opaque"
-  "pub"
   "todo"
   "try"
   "type"

--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -10,11 +10,7 @@
 ; Functions
 (function
   name: (identifier) @name) @definition.function
-(public_function
-  name: (identifier) @name) @definition.function
 (external_function
-  name: (identifier) @name) @definition.function
-(public_external_function
   name: (identifier) @name) @definition.function
 (unqualified_import (identifier) @name) @reference.function
 ((function_call
@@ -30,24 +26,14 @@
  (#is-not? local)) @reference.function
 
 ; Types
-(public_type_definition
-  (type_name
-    name: (type_identifier) @name)) @definition.type
 (type_definition
   (type_name
     name: (type_identifier) @name)) @definition.type
-(public_type_definition
-  (data_constructors
-    (data_constructor
-      name: (type_identifier) @name))) @definition.type
 (type_definition
   (data_constructors
     (data_constructor
       name: (type_identifier) @name))) @definition.type
 (external_type
-  (type_name
-    name: (type_identifier) @name)) @definition.type
-(public_external_type
   (type_name
     name: (type_identifier) @name)) @definition.type
 

--- a/test/corpus/constants.txt
+++ b/test/corpus/constants.txt
@@ -224,21 +224,25 @@ pub const a = uri.Uri(host: "github.com")
 --------------------------------------------------------------------------------
 
 (source_file
-  (public_constant
+  (constant
+    (visibility_modifier)
     name: (identifier)
     value: (string
       (quoted_content)))
-  (public_constant
+  (constant
+    (visibility_modifier)
     name: (identifier)
     type: (type
       name: (type_identifier))
     value: (integer))
-  (public_constant
+  (constant
+    (visibility_modifier)
     name: (identifier)
     type: (type
       name: (type_identifier))
     value: (float))
-  (public_constant
+  (constant
+    (visibility_modifier)
     name: (identifier)
     type: (tuple_type
       (type
@@ -249,11 +253,13 @@ pub const a = uri.Uri(host: "github.com")
       (integer)
       (string
         (quoted_content))))
-  (public_constant
+  (constant
+    (visibility_modifier)
     name: (identifier)
     type: (tuple_type)
     value: (tuple))
-  (public_constant
+  (constant
+    (visibility_modifier)
     name: (identifier)
     type: (type
       name: (type_identifier)
@@ -264,7 +270,8 @@ pub const a = uri.Uri(host: "github.com")
     value: (list
       (integer)
       (integer)))
-  (public_constant
+  (constant
+    (visibility_modifier)
     name: (identifier)
     type: (type
       name: (type_identifier)
@@ -272,12 +279,14 @@ pub const a = uri.Uri(host: "github.com")
         (type_argument
           (type_hole))))
     value: (list))
-  (public_constant
+  (constant
+    (visibility_modifier)
     name: (identifier)
     value: (bit_string
       (bit_string_segment
         value: (integer))))
-  (public_constant
+  (constant
+    (visibility_modifier)
     name: (identifier)
     value: (bit_string
       (bit_string_segment
@@ -292,14 +301,16 @@ pub const a = uri.Uri(host: "github.com")
         value: (integer)
         options: (bit_string_segment_options
           (integer)))))
-  (public_constant
+  (constant
+    (visibility_modifier)
     name: (identifier)
     value: (bit_string
       (bit_string_segment
         value: (integer)
         options: (bit_string_segment_options
           (bit_string_segment_option_size)))))
-  (public_constant
+  (constant
+    (visibility_modifier)
     name: (identifier)
     value: (bit_string
       (bit_string_segment
@@ -307,7 +318,8 @@ pub const a = uri.Uri(host: "github.com")
         options: (bit_string_segment_options
           (bit_string_segment_option_size)
           (bit_string_segment_option_unit)))))
-  (public_constant
+  (constant
+    (visibility_modifier)
     name: (identifier)
     value: (bit_string
       (bit_string_segment
@@ -315,16 +327,19 @@ pub const a = uri.Uri(host: "github.com")
           (quoted_content))
         options: (bit_string_segment_options
           (bit_string_segment_option_utf8)))))
-  (public_constant
+  (constant
+    (visibility_modifier)
     name: (identifier)
     value: (record
       name: (type_identifier)))
-  (public_constant
+  (constant
+    (visibility_modifier)
     name: (identifier)
     value: (record
       name: (type_identifier)
       arguments: (arguments)))
-  (public_constant
+  (constant
+    (visibility_modifier)
     name: (identifier)
     value: (record
       name: (type_identifier)
@@ -334,7 +349,8 @@ pub const a = uri.Uri(host: "github.com")
             (quoted_content)))
         (argument
           value: (integer)))))
-  (public_constant
+  (constant
+    (visibility_modifier)
     name: (identifier)
     value: (record
       name: (type_identifier)
@@ -346,7 +362,8 @@ pub const a = uri.Uri(host: "github.com")
         (argument
           label: (label)
           value: (integer)))))
-  (public_constant
+  (constant
+    (visibility_modifier)
     name: (identifier)
     value: (record
       name: (remote_type_identifier

--- a/test/corpus/custom_types.txt
+++ b/test/corpus/custom_types.txt
@@ -173,7 +173,8 @@ pub type Animal(name, cuteness) {
 --------------------------------------------------------------------------------
 
 (source_file
-  (public_type_definition
+  (type_definition
+    (visibility_modifier)
     (type_name
       name: (type_identifier)
       parameters: (type_parameters
@@ -215,7 +216,9 @@ pub opaque type Animal(name, cuteness) {
 --------------------------------------------------------------------------------
 
 (source_file
-  (public_opaque_type_definition
+  (type_definition
+    (visibility_modifier)
+    (opacity_modifier)
     (type_name
       name: (type_identifier)
       parameters: (type_parameters

--- a/test/corpus/destructuring.txt
+++ b/test/corpus/destructuring.txt
@@ -12,7 +12,8 @@ pub fn main() {
 --------------------------------------------------------------------------------
 
 (source_file
-  (public_function
+  (function
+    (visibility_modifier)
     (identifier)
     (function_parameters)
     (function_body

--- a/test/corpus/external_functions.txt
+++ b/test/corpus/external_functions.txt
@@ -1,13 +1,13 @@
-===================
+================================================================================
 External functions
-===================
+================================================================================
 
 external fn read_file(String) -> Result(String, Reason) =
   "file" "open"
 external fn a(name: String) -> String = "x" "y"
 external fn a() -> #(List(Int), fn(Int) -> String) = "x" "y"
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (external_function
@@ -66,19 +66,20 @@ external fn a() -> #(List(Int), fn(Int) -> String) = "x" "y"
       (string
         (quoted_content)))))
 
-==========================
+================================================================================
 Public external functions
-==========================
+================================================================================
 
 pub external fn read_file(String) -> Result(String, Reason) =
   "file" "open"
 pub external fn a(name: String) -> String = "x" "y"
 pub external fn a() -> #(List(Int), fn(Int) -> String) = "x" "y"
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-  (public_external_function
+  (external_function
+    (visibility_modifier)
     name: (identifier)
     parameters: (function_parameters
       (function_parameter
@@ -98,7 +99,8 @@ pub external fn a() -> #(List(Int), fn(Int) -> String) = "x" "y"
         (quoted_content))
       (string
         (quoted_content))))
-  (public_external_function
+  (external_function
+    (visibility_modifier)
     name: (identifier)
     parameters: (function_parameters
       (function_parameter
@@ -112,7 +114,8 @@ pub external fn a() -> #(List(Int), fn(Int) -> String) = "x" "y"
         (quoted_content))
       (string
         (quoted_content))))
-  (public_external_function
+  (external_function
+    (visibility_modifier)
     name: (identifier)
     parameters: (function_parameters)
     return_type: (tuple_type

--- a/test/corpus/external_types.txt
+++ b/test/corpus/external_types.txt
@@ -1,12 +1,12 @@
-===============
+================================================================================
 External types
-===============
+================================================================================
 
 external type IODevice
 external type IODevice()
 external type Map(key, value)
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (external_type
@@ -23,25 +23,28 @@ external type Map(key, value)
         (type_parameter)
         (type_parameter)))))
 
-======================
+================================================================================
 Public external types
-======================
+================================================================================
 
 pub external type IODevice
 pub external type IODevice()
 pub external type Map(key, value)
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-  (public_external_type
+  (external_type
+    (visibility_modifier)
     (type_name
       name: (type_identifier)))
-  (public_external_type
+  (external_type
+    (visibility_modifier)
     (type_name
       name: (type_identifier)
       parameters: (type_parameters)))
-  (public_external_type
+  (external_type
+    (visibility_modifier)
     (type_name
       name: (type_identifier)
       parameters: (type_parameters

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -127,7 +127,8 @@ pub fn replace(
 --------------------------------------------------------------------------------
 
 (source_file
-  (public_function
+  (function
+    (visibility_modifier)
     name: (identifier)
     parameters: (function_parameters
       (function_parameter
@@ -144,7 +145,8 @@ pub fn replace(
       (binary_expression
         left: (identifier)
         right: (identifier))))
-  (public_function
+  (function
+    (visibility_modifier)
     name: (identifier)
     parameters: (function_parameters
       (function_parameter
@@ -167,14 +169,16 @@ pub fn replace(
               arguments: (arguments
                 (argument
                   value: (identifier)))))))))
-  (public_function
+  (function
+    (visibility_modifier)
     name: (identifier)
     parameters: (function_parameters
       (function_parameter
         name: (identifier)))
     body: (function_body
       (identifier)))
-  (public_function
+  (function
+    (visibility_modifier)
     name: (identifier)
     parameters: (function_parameters
       (function_parameter

--- a/test/corpus/type_aliases.txt
+++ b/test/corpus/type_aliases.txt
@@ -1,13 +1,13 @@
-============
+================================================================================
 Type aliases
-============
+================================================================================
 
 type Headers =
   List(#(String, String))
 type Box(a) = #(a)
 type NamedBox(a) = #(String, a)
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (type_alias
@@ -39,19 +39,20 @@ type NamedBox(a) = #(String, a)
         name: (type_identifier))
       (type_var))))
 
-===================
+================================================================================
 Public type aliases
-===================
+================================================================================
 
 pub type Headers =
   List(#(String, String))
 pub type Box(a) = #(a)
 pub type NamedBox(a) = #(String, a)
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-  (public_type_alias
+  (type_alias
+    (visibility_modifier)
     (type_name
       name: (type_identifier))
     (type
@@ -63,14 +64,16 @@ pub type NamedBox(a) = #(String, a)
               name: (type_identifier))
             (type
               name: (type_identifier)))))))
-  (public_type_alias
+  (type_alias
+    (visibility_modifier)
     (type_name
       name: (type_identifier)
       parameters: (type_parameters
         (type_parameter)))
     (tuple_type
       (type_var)))
-  (public_type_alias
+  (type_alias
+    (visibility_modifier)
     (type_name
       name: (type_identifier)
       parameters: (type_parameters
@@ -80,19 +83,21 @@ pub type NamedBox(a) = #(String, a)
         name: (type_identifier))
       (type_var))))
 
-==========================
+================================================================================
 Public opaque type aliases
-==========================
+================================================================================
 
 pub opaque type Headers =
   List(#(String, String))
 pub opaque type Box(a) = #(a)
 pub opaque type NamedBox(a) = #(String, a)
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-  (public_opaque_type_alias
+  (type_alias
+    (visibility_modifier)
+    (opacity_modifier)
     (type_name
       name: (type_identifier))
     (type
@@ -104,14 +109,18 @@ pub opaque type NamedBox(a) = #(String, a)
               name: (type_identifier))
             (type
               name: (type_identifier)))))))
-  (public_opaque_type_alias
+  (type_alias
+    (visibility_modifier)
+    (opacity_modifier)
     (type_name
       name: (type_identifier)
       parameters: (type_parameters
         (type_parameter)))
     (tuple_type
       (type_var)))
-  (public_opaque_type_alias
+  (type_alias
+    (visibility_modifier)
+    (opacity_modifier)
     (type_name
       name: (type_identifier)
       parameters: (type_parameters

--- a/test/corpus/whole_files.txt
+++ b/test/corpus/whole_files.txt
@@ -34,7 +34,8 @@ if javascript {
     module: (module))
   (statement_comment)
   (statement_comment)
-  (public_function
+  (function
+    (visibility_modifier)
     name: (identifier)
     parameters: (function_parameters
       (function_parameter
@@ -173,7 +174,8 @@ pub fn negate(bool: Bool) -> Bool {
   (statement_comment)
   (statement_comment)
   (statement_comment)
-  (public_function
+  (function
+    (visibility_modifier)
     name: (identifier)
     parameters: (function_parameters
       (function_parameter


### PR DESCRIPTION
closes #17

This refactor brings this grammar more in line with tree-sitter-rust.
A function or type declaration may have a visibility modifier ("pub") and
type declarations may also have an opacity modifier ("opaque"). This ends
up reducing the number of named rules, which cleans up the queries a bit.