### PR TITLE
add unit tests for tags.scm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "prettier": "^2.5.1",
-        "tree-sitter-cli": "^0.20.4"
+        "tree-sitter-cli": "^0.20.6"
       }
     },
     "node_modules/nan": {
@@ -34,9 +34,9 @@
       }
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.20.4",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.4.tgz",
-      "integrity": "sha512-G42x0Ev7mxA8WLUfZY+two5LIhPf6R/m7qDZtKxOzE77zXi6didNI/vf17kHaKaRXJrWnyCxHFaVQFO2LL81yg==",
+      "version": "0.20.6",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.6.tgz",
+      "integrity": "sha512-tjbAeuGSMhco/EnsThjWkQbDIYMDmdkWsTPsa/NJAW7bjaki9P7oM9TkLxfdlnm4LXd1wR5wVSM2/RTLtZbm6A==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -57,9 +57,9 @@
       "dev": true
     },
     "tree-sitter-cli": {
-      "version": "0.20.4",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.4.tgz",
-      "integrity": "sha512-G42x0Ev7mxA8WLUfZY+two5LIhPf6R/m7qDZtKxOzE77zXi6didNI/vf17kHaKaRXJrWnyCxHFaVQFO2LL81yg==",
+      "version": "0.20.6",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.6.tgz",
+      "integrity": "sha512-tjbAeuGSMhco/EnsThjWkQbDIYMDmdkWsTPsa/NJAW7bjaki9P7oM9TkLxfdlnm4LXd1wR5wVSM2/RTLtZbm6A==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "prettier": "^2.5.1",
-    "tree-sitter-cli": "^0.20.4"
+    "tree-sitter-cli": "^0.20.6"
   },
   "tree-sitter": [
     {

--- a/test/tags/frame.gleam
+++ b/test/tags/frame.gleam
@@ -1,0 +1,75 @@
+import gleam/option.{Option, Some, None}
+//      ^ reference.module
+//                    ^ reference.type
+//                            ^ reference.type
+//                                  ^ reference.type
+import gleam/bit_builder
+//      ^ reference.module
+
+pub type FrameData {
+  //      ^ definition.type
+  Text(String)
+  // <- definition.type
+  //    ^ reference.type
+  Binary(BitString)
+  Continuation(BitString)
+  Ping(BitString)
+  Pong(BitString)
+  Close(code: Option(Int), reason: Option(String))
+  // <- definition.type
+  //            ^ reference.type
+  //                  ^ reference.type
+  //                                ^ reference.type
+  //                                       ^ reference.type
+}
+
+pub type Frame {
+  //      ^ definition.type
+  Frame(reserved: BitString, mask: Option(BitString), data: FrameData, fin: Bool)
+}
+
+fn encode_frame(frame: Frame) -> bit_builder.BitBuilder {
+//  ^ definition.function
+//                      ^ reference.type
+//                                ^ reference.module
+//                                             ^ reference.type
+  let fin =
+    case frame.fin {
+      True -> <<1:size(1)>>
+      False -> <<0:size(1)>>
+    }
+
+  let opcode =
+    case frame.data {
+      Continuation(_) -> <<0x0:size(1)>>
+      // <- reference.type
+      Text(_) -> <<0x1:size(1)>>
+      Binary(_) -> <<0x2:size(1)>>
+      // 0x3-7 reserved for future non-control frames
+      Close(..) -> <<0x8:size(1)>>
+      Pong(_) -> <<0x9:size(1)>>
+      Pong(_) -> <<0xA:size(1)>>
+    }
+
+  let is_masked_bit =
+    case frame.mask {
+      Some(_) -> <<1:size(1)>>
+      None -> <<0:size(1)>>
+    }
+
+  bit_builder.new()
+  // <- reference.module
+  //           ^ reference.function
+  |> bit_builder.append(fin)
+  //              ^ reference.function
+  |> bit_builder.append(frame.reserved)
+  |> bit_builder.append(opcode)
+  |> bit_builder.append(is_masked_bit)
+  |> bit_builder.append(option.unwrap(frame.mask, <<>>))
+  // ^ reference.module
+  //                     ^ reference.module
+  //                            ^ reference.function
+  |> bit_builder.append(mask_data(frame))
+  //                     ^ reference.function
+}
+

--- a/test/tags/functions.gleam
+++ b/test/tags/functions.gleam
@@ -1,0 +1,10 @@
+fn record_with_fun_field(record) {
+  let foo = Bar(baz: fn(x) { x + 1 })
+  //         ^ reference.type
+  foo.baz(41)
+  record.foobar("hello")
+
+  string.replace("hello", "l", "o")
+  // ^ reference.module
+  //     ^ reference.function
+}


### PR DESCRIPTION
tree-sitter v0.20.6 was just published that has a [new testing mechanism for tags queries](https://github.com/tree-sitter/tree-sitter/pull/1547), so I've added some unit tests. I'm not very creative with the fixture, it was just some code I had locally. Are there any edge cases we want to cover? Maybe we should add some for the module+function vs. record+field stuff?