### PR TITLE
generalize bit string option node

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -588,27 +588,26 @@ module.exports = grammar({
     _decimal: ($) => /[0-9][0-9_]*/,
     _octal: ($) => /0[oO][0-7_]+/,
     _binary: ($) => /0[bB][0-1_]+/,
-    _bit_string_segment_option_unit: ($) =>
-      seq("unit", "(", alias($.integer, $.bit_string_segment_option_unit), ")"),
-    _bit_string_segment_option_literal: ($) =>
+    _bit_string_segment_option: ($) =>
       choice(
-        alias("binary", $.bit_string_segment_option_binary),
-        alias("bytes", $.bit_string_segment_option_binary),
-        alias("int", $.bit_string_segment_option_int),
-        alias("float", $.bit_string_segment_option_float),
-        alias("bit_string", $.bit_string_segment_option_bit_string),
-        alias("bits", $.bit_string_segment_option_bit_string),
-        alias("utf8", $.bit_string_segment_option_utf8),
-        alias("utf16", $.bit_string_segment_option_utf16),
-        alias("utf32", $.bit_string_segment_option_utf32),
-        alias("utf8_codepoint", $.bit_string_segment_option_utf8_codepoint),
-        alias("utf16_codepoint", $.bit_string_segment_option_utf16_codepoint),
-        alias("utf32_codepoint", $.bit_string_segment_option_utf32_codepoint),
-        alias("signed", $.bit_string_segment_option_signed),
-        alias("unsigned", $.bit_string_segment_option_unsigned),
-        alias("big", $.bit_string_segment_option_big),
-        alias("little", $.bit_string_segment_option_little),
-        alias("native", $.bit_string_segment_option_native)
+        "binary",
+        "bytes",
+        "int",
+        "float",
+        "bit_string",
+        "bits",
+        "utf8",
+        "utf16",
+        "utf32",
+        "utf8_codepoint",
+        "utf16_codepoint",
+        "utf32_codepoint",
+        "signed",
+        "unsigned",
+        "big",
+        "little",
+        "native",
+        seq("unit", "(", $.integer, ")")
       ),
 
     /* Types */
@@ -710,18 +709,15 @@ function bit_string_segment_options(name, arg_parser) {
     [`_${name}_bit_string_segment_option`]: ($) =>
       choice($[`_${name}_bit_string_named_segment_option`], $.integer),
     [`_${name}_bit_string_named_segment_option`]: ($) =>
-      choice(
-        $._bit_string_segment_option_unit,
-        $[`_${name}_bit_string_segment_option_size`],
-        $._bit_string_segment_option_literal
+      alias(
+        choice(
+          $._bit_string_segment_option,
+          $[`_${name}_bit_string_segment_option_size`]
+        ),
+        $.bit_string_segment_option
       ),
     [`_${name}_bit_string_segment_option_size`]: ($) =>
-      seq(
-        "size",
-        "(",
-        alias($[arg_parser], $.bit_string_segment_option_size),
-        ")"
-      ),
+      seq("size", "(", $[arg_parser], ")"),
   };
 }
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -47,6 +47,7 @@
 
 ; Literals
 (string) @string
+(bit_string_segment_option) @function.builtin
 (integer) @number
 (float) @number
 
@@ -84,6 +85,8 @@
   "]"
   "{"
   "}"
+  "<<"
+  ">>"
 ] @punctuation.bracket
 [
   "."
@@ -94,4 +97,5 @@
   "="
   "->"
   ".."
+  "-"
 ] @punctuation.delimiter

--- a/test/corpus/constants.txt
+++ b/test/corpus/constants.txt
@@ -121,15 +121,18 @@ const a: option.Option(String) = option.Some("Hello, World!")
       (bit_string_segment
         value: (integer)
         options: (bit_string_segment_options
-          (bit_string_segment_option_size)))))
+          (bit_string_segment_option
+            (integer))))))
   (constant
     name: (identifier)
     value: (bit_string
       (bit_string_segment
         value: (integer)
         options: (bit_string_segment_options
-          (bit_string_segment_option_size)
-          (bit_string_segment_option_unit)))))
+          (bit_string_segment_option
+            (integer))
+          (bit_string_segment_option
+            (integer))))))
   (constant
     name: (identifier)
     value: (bit_string
@@ -137,7 +140,7 @@ const a: option.Option(String) = option.Some("Hello, World!")
         value: (string
           (quoted_content))
         options: (bit_string_segment_options
-          (bit_string_segment_option_utf8)))))
+          (bit_string_segment_option)))))
   (constant
     name: (identifier)
     value: (record
@@ -308,7 +311,8 @@ pub const a = uri.Uri(host: "github.com")
       (bit_string_segment
         value: (integer)
         options: (bit_string_segment_options
-          (bit_string_segment_option_size)))))
+          (bit_string_segment_option
+            (integer))))))
   (constant
     (visibility_modifier)
     name: (identifier)
@@ -316,8 +320,10 @@ pub const a = uri.Uri(host: "github.com")
       (bit_string_segment
         value: (integer)
         options: (bit_string_segment_options
-          (bit_string_segment_option_size)
-          (bit_string_segment_option_unit)))))
+          (bit_string_segment_option
+            (integer))
+          (bit_string_segment_option
+            (integer))))))
   (constant
     (visibility_modifier)
     name: (identifier)
@@ -326,7 +332,7 @@ pub const a = uri.Uri(host: "github.com")
         value: (string
           (quoted_content))
         options: (bit_string_segment_options
-          (bit_string_segment_option_utf8)))))
+          (bit_string_segment_option)))))
   (constant
     (visibility_modifier)
     name: (identifier)

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -764,11 +764,11 @@ fn try_try_again(x, y) -> Int {
           (bit_string_segment
             value: (identifier)
             options: (bit_string_segment_options
-              (bit_string_segment_option_utf8)))
+              (bit_string_segment_option)))
           (bit_string_segment
             value: (identifier)
             options: (bit_string_segment_options
-              (bit_string_segment_option_size
+              (bit_string_segment_option
                 (integer)))))
         value: (todo))
       (try

--- a/test/highlight/bit_strings.gleam
+++ b/test/highlight/bit_strings.gleam
@@ -1,0 +1,27 @@
+fn bit_strings() {
+  <<3>>
+  // <- punctuation.bracket
+  //^ number
+  // ^ punctuation.bracket
+  <<3:8>>
+  //^ number
+  // ^ punctuation.delimiter
+  //  ^ number
+  <<3:size(8)>>
+  //^ number
+  // ^ punctuation.delimiter
+  //   ^ function.builtin
+  //      ^ punctuation.bracket
+  //       ^ number
+  //        ^ punctuation.bracket
+  <<code:int-size(8)-unit(2), reason:utf8>>
+  // ^ variable
+  //      ^ function.builtin
+  //        ^ punctuation.delimiter
+  //          ^ function.builtin
+  //              ^ number
+  //                  ^ function.builtin
+  //                      ^ number
+  //                             ^ variable
+  //                                   ^ function.builtin
+}


### PR DESCRIPTION
closes #19

It ended up being a pretty small refactor to the grammar, only really changing around what and where things are aliased. I also added some highlight tests for it with the capture `@function.builtin`. That doesn't really feel like the perfect capture, I'm open to suggestions!